### PR TITLE
fix(Comment.validator): get comments validator

### DIFF
--- a/server/src/middleware/Comment.validator.js
+++ b/server/src/middleware/Comment.validator.js
@@ -24,7 +24,7 @@ export class CommentValidator{
     }
 
     async getCommentsFromPostValidation(req, res, next){
-        const { postId } = req.body
+        const { postId } = req.params
         if (!postId){
             return res.status(404).json({
                 message: `Missing post's id`


### PR DESCRIPTION
Adjusting it to be able to pass the post's id through the url